### PR TITLE
Fix to missing parameter in endTimedEvent withParameters call.

### DIFF
--- a/FlurryPhoneGapPlugin.m
+++ b/FlurryPhoneGapPlugin.m
@@ -156,7 +156,7 @@
     @try {
         NSString* event = [command.arguments objectAtIndex:0];
        
-        [Flurry endTimedEvent:event];
+        [Flurry endTimedEvent:event withParameters:nil];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         javaScript = [pluginResult toSuccessCallbackString:command.callbackId];
     }


### PR DESCRIPTION
Had trouble compiling with Flurry 4.1 and Cordova 2.4.0, with this fix all seem to work fine.
