### PR TITLE
Deep copying parameter dictionaries on iOS

### DIFF
--- a/src/ios/FlurryPlugin.m
+++ b/src/ios/FlurryPlugin.m
@@ -95,7 +95,7 @@
     
     @try {
         NSString* event = [command.arguments objectAtIndex:0];
-        NSDictionary* parameters = [command.arguments objectAtIndex:1];
+        NSDictionary* parameters = [NSDictionary dictionaryWithDictionary:[command.arguments objectAtIndex:1]];
         
         [Flurry logEvent:event withParameters:parameters];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
@@ -160,7 +160,7 @@
     {
 
         NSString* event = [command.arguments objectAtIndex:0];
-        NSDictionary* parameters = [command.arguments objectAtIndex:1];
+        NSDictionary* parameters = [NSDictionary dictionaryWithDictionary:[command.arguments objectAtIndex:1]];
         bool Timed = [[command.arguments objectAtIndex:2]boolValue];
 
         [Flurry logEvent:event withParameters:parameters timed:Timed];
@@ -184,7 +184,7 @@
     
     @try {
         NSString* event = [command.arguments objectAtIndex:0];
-        NSDictionary* parameters = [command.arguments objectAtIndex:1];
+        NSDictionary* parameters = [NSDictionary dictionaryWithDictionary:[command.arguments objectAtIndex:1]];
         
         [Flurry endTimedEvent:event withParameters:parameters];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
Seems like flurry lib stores the event related calls and sends them to flurry servers delayed a few seconds. This creates a crash on iOS (on my iOS8 test device), since cordova plugin command arguments are destroyed and parameter dictionaries are not mutated. Copying the param to a new dictionary object to fix.
