### PR TITLE
Fixes for flurry's android namespace + android session + ios threading

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -35,7 +35,7 @@
 	<platform name="android">
 		<config-file target="res/xml/config.xml" parent="/*">
 			<feature name="FlurryPlugin">
-				<param name="android-package" value="com.phonegap.plugins.Flurry.Flurry" />
+				<param name="android-package" value="com.phonegap.plugins.Flurry" />
 			</feature>
 		</config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,7 +35,7 @@
 	<platform name="android">
 		<config-file target="res/xml/config.xml" parent="/*">
 			<feature name="FlurryPlugin">
-				<param name="android-package" value="com.phonegap.plugins.Flurry" />
+				<param name="android-package" value="com.phonegap.plugins.flurry.Flurry" />
 			</feature>
 		</config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,7 +35,7 @@
 	<platform name="android">
 		<config-file target="res/xml/config.xml" parent="/*">
 			<feature name="FlurryPlugin">
-				<param name="android-package" value="com.phonegap.plugins.Flurry" />
+				<param name="android-package" value="com.phonegap.plugins.Flurry.Flurry" />
 			</feature>
 		</config-file>
 

--- a/src/android/Flurry.java
+++ b/src/android/Flurry.java
@@ -35,7 +35,8 @@ public class Flurry extends CordovaPlugin {
         try{
             Log.d("Flurry", action);
             if(action.equals("startSession")) {
-                FlurryAgent.onStartSession(cordova.getActivity().getApplicationContext(), args.getString(0));
+                FlurryAgent.init(cordova.getActivity().getApplicationContext(), args.getString(0));
+                FlurryAgent.onStartSession(cordova.getActivity().getBaseContext(), args.getString(0));
             } else if(action.equals("endSession")) {
                 FlurryAgent.onEndSession(cordova.getActivity().getApplicationContext());
             } else if(action.equals("setSessionContinueSeconds")) {

--- a/src/ios/FlurryPlugin.m
+++ b/src/ios/FlurryPlugin.m
@@ -53,7 +53,7 @@
         
         @try {
             if (key != nil) {
-                [Flurry startSession: key];
+                dispatch_sync(dispatch_get_main_queue(), ^{[Flurry startSession: key];});
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
                 // starting Flurry - Update Key before releasing
             }


### PR DESCRIPTION
There are three main parts to this PR:

1. Fix for the flurry namespace on Android as mentioned in: #18

2. Fix for starting the flurry session on Android as mentioned in: http://stackoverflow.com/a/27587928

3. Fix for the app crashing on launch for iOS because of a threading issue. **Hetul Patel** from Flurry had this to say:
> You should be calling startSession from the main thread, in the AppDelegate's applicationDidLoad function.