### PR TITLE
Fix for setGender and onEndSession on Android

### DIFF
--- a/src/android/Flurry.java
+++ b/src/android/Flurry.java
@@ -8,6 +8,7 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import android.util.Log;
 
+import com.flurry.android.Constants;
 import com.flurry.android.FlurryAgent;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -46,7 +47,14 @@ public class Flurry extends CordovaPlugin {
             } else if(action.equals("setUserID")) {
                 FlurryAgent.setUserId(args.getString(0));
             } else if(action.equals("setGender")) {
-                FlurryAgent.setGender((byte)args.getLong(0));
+                byte gender = Constants.UNKNOWN;
+                if (args.getString(0) == "m") {
+                    gender = Constants.MALE;
+                }
+                else if (args.getString(0) == "f") {
+                    gender = Constants.FEMALE;
+                }
+                FlurryAgent.setGender(gender);
             } else if(action.equals("setAge")) {
                 FlurryAgent.setAge((int)args.getLong(0));
             } else if (action.equals("logEvent") || action.equals("logEventWithParameters")

--- a/src/android/Flurry.java
+++ b/src/android/Flurry.java
@@ -39,7 +39,7 @@ public class Flurry extends CordovaPlugin {
                 FlurryAgent.init(cordova.getActivity().getApplicationContext(), args.getString(0));
                 FlurryAgent.onStartSession(cordova.getActivity().getBaseContext(), args.getString(0));
             } else if(action.equals("endSession")) {
-                FlurryAgent.onEndSession(cordova.getActivity().getApplicationContext());
+                FlurryAgent.onEndSession(cordova.getActivity().getBaseContext());
             } else if(action.equals("setSessionContinueSeconds")) {
                 FlurryAgent.setContinueSessionMillis(args.getLong(0));
             } else if(action.equals("setAppVersion")) {


### PR DESCRIPTION
I've been getting logcat warnings about flurry `setGender`:

```
D/Flurry﹕ setGender
D/Flurry exception:﹕ Value m at 0 of type java.lang.String cannot be converted to long
```

This fixes that issue by matching what the iOS API does.

---

This also fixes flurry `onEndSession` context issues:

```
    java.lang.IllegalArgumentException: Cannot end a session with an Application context
            at com.flurry.android.FlurryAgent.onEndSession(SourceFile:424)
```