### PR TITLE
Removed deprecated dependency android.support.v4 and did not add it back

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Unfortunately the policy of Flurry doesn't allow to include the SDK in this repo
     - Android:
         - Copy `FlurryAgent-*.jar` lib to your lib dir manually.
         - Plugin automatically adds references to Google Play Services and Android v4 support lib.
-        - If you already have `android-support-v4.jar` lib referenced in your project and get error messages, delete the new one in your libs folder.
+        - If you do not have `android-support-vX.jar` lib referenced in your project and get error messages, install it by following instructions at http://developer.android.com/tools/support-library/features.html#v4.
     - iOS:
         - Copy `libFlurry_*.a` lib to your lib dir manually.
         - Plugin automatically adds references to Security and SystemConfiguration frameworks.

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,8 +41,7 @@
 
 		<source-file src="src/android/Flurry.java"
 					target-dir="src/com/phonegap/plugins/flurry/" />
-		<dependency id="com.google.playservices" />
-		<dependency id="android.support.v4" />
+        <framework src="com.google.android.gms:play-services-plus:+" />
 		<config-file target="AndroidManifest.xml" parent="/*/application">
 			<meta-data android:name="com.google.android.gms.version"
 			  android:value="@integer/google_play_services_version"/>


### PR DESCRIPTION
because it does oftentimes already exist in Cordova generated Android
project and so rather than deleting it users should just install it
Replaced com.google.playservices dependency with
com.google.android.gms:play-services-plus framework